### PR TITLE
feat: update contribution guidelines and enhance band page styling

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -30,6 +30,8 @@ yarn dev/build/lint/test/clean
 - Zod for all inputs; try/catch error handling.
 - Absolute imports from src/.
 - When fixing a bug or an error analyse the code carefully. Make sure to break nothing else when fixing something!
+- Create a new feature branch when working on a new feature: feat/NAME_OF_THE_FEATURE
+- Create a new fix branch when fixing a new bug/error: fix/NAME_OF_THE_BUG
 
 ## Styling Guidelines
 

--- a/app/band/[slug]/page.module.scss
+++ b/app/band/[slug]/page.module.scss
@@ -5,15 +5,18 @@
   margin-bottom: 20px;
 }
 
-.genresRow {
-  margin-top: 10px;
+// ConcertCount is globally styled (nested `.badge`) to be intentionally prominent.
+// On the band page only, shrink it without changing its shape.
+.headerRow h2 > :global(.badge) {
+  display: inline-block;
+  transform: scale(0.78);
+  transform-origin: left center;
 }
 
 .genreBadges {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-left: 6px;
 }
 
 .genreBadge {
@@ -24,11 +27,45 @@
   background: rgba(0, 0, 0, 0.08);
 }
 
-.lastfmLinkRow {
+.metaRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
   margin-top: 10px;
+  color: rgba(0, 0, 0, 0.65);
+  line-height: 1.2;
+}
+
+.metaSeparator {
+  color: rgba(0, 0, 0, 0.35);
 }
 
 .lastfmLink {
-  text-decoration: underline;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 999px;
+  color: rgba(0, 0, 0, 0.6);
+  background: transparent;
+  border: 0;
+  transition:
+    color 200ms ease-out;
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
+  }
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.75);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #ff0666;
+    outline-offset: 3px;
+  }
 }
 

--- a/app/band/[slug]/page.tsx
+++ b/app/band/[slug]/page.tsx
@@ -1,44 +1,59 @@
-import React from 'react';
-import Layout from '../../../src/components/layout-client';
-import ConcertCard from '../../../src/components/ConcertCard/concertCard';
-import ConcertCount from '../../../src/components/ConcertCount/concertCount';
-import { getAllBands, getConcertsByBand, getAllConcerts } from '../../../src/utils/data';
-import { isFeatureEnabled, FEATURE_FLAGS } from '../../../src/utils/featureFlags';
-import type { Metadata } from 'next';
-import styles from './page.module.scss';
+import React from "react"
+import Layout from "../../../src/components/layout-client"
+import ConcertCard from "../../../src/components/ConcertCard/concertCard"
+import ConcertCount from "../../../src/components/ConcertCount/concertCount"
+import {
+  getAllBands,
+  getConcertsByBand,
+  getAllConcerts,
+} from "../../../src/utils/data"
+import {
+  isFeatureEnabled,
+  FEATURE_FLAGS,
+} from "../../../src/utils/featureFlags"
+import type { Metadata } from "next"
+import styles from "./page.module.scss"
 
-export const dynamic = 'force-static';
+export const dynamic = "force-static"
 
 export async function generateStaticParams() {
-  const bands = await getAllBands();
+  const bands = await getAllBands()
   return bands.map((band) => ({
     slug: band.slug,
-  }));
+  }))
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
-  const { slug } = await params;
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
   // Fetch data once and reuse
   const [bands, allConcerts] = await Promise.all([
     getAllBands(),
     getAllConcerts(),
-  ]);
-  const band = bands.find((b) => b.slug === slug);
-  
+  ])
+  const band = bands.find((b) => b.slug === slug)
+
   return {
     title: `${band?.name || slug} | Concerts`,
-  };
+  }
 }
 
-export default async function BandPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
+export default async function BandPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
   // Fetch data once and reuse (prevents duplicate API calls)
   const [bands, allConcerts] = await Promise.all([
     getAllBands(),
     getAllConcerts(),
-  ]);
-  const band = bands.find((b) => b.slug === slug);
-  const concerts = await getConcertsByBand(slug);
+  ])
+  const band = bands.find((b) => b.slug === slug)
+  const concerts = await getConcertsByBand(slug)
 
   if (!band) {
     return (
@@ -50,14 +65,17 @@ export default async function BandPage({ params }: { params: Promise<{ slug: str
           </div>
         </main>
       </Layout>
-    );
+    )
   }
 
   const concertsFormatted = {
-    edges: concerts.map(c => ({ node: c })),
+    edges: concerts.map((c) => ({ node: c })),
     totalCount: concerts.length,
-  };
-  const lastfmEnabled = isFeatureEnabled(FEATURE_FLAGS.ENABLE_LASTFM, true);
+  }
+  const lastfmEnabled = isFeatureEnabled(FEATURE_FLAGS.ENABLE_LASTFM, true)
+  const hasGenres =
+    lastfmEnabled && band.lastfm?.genres && band.lastfm.genres.length > 0
+  const hasLastfmUrl = lastfmEnabled && Boolean(band.lastfm?.url)
 
   return (
     <Layout concerts={allConcerts}>
@@ -69,23 +87,54 @@ export default async function BandPage({ params }: { params: Promise<{ slug: str
                 {band.name}
                 <ConcertCount concerts={concertsFormatted} />
               </h2>
-              {lastfmEnabled && band.lastfm?.genres && band.lastfm.genres.length > 0 && (
-                <div className={styles.genresRow}>
-                  <strong>Genres:</strong>
-                  <span className={styles.genreBadges}>
-                    {band.lastfm.genres.slice(0, 5).map((genre) => (
-                      <span key={genre} className={styles.genreBadge}>
-                        {genre}
-                      </span>
-                    ))}
-                  </span>
-                </div>
-              )}
-              {lastfmEnabled && band.lastfm?.url && (
-                <div className={styles.lastfmLinkRow}>
-                  <a className={styles.lastfmLink} href={band.lastfm.url} target="_blank" rel="noopener noreferrer">
-                    View on Last.fm →
-                  </a>
+              {(hasGenres || hasLastfmUrl) && (
+                <div className={styles.metaRow}>
+                  {hasGenres && (
+                    <span className={styles.genreBadges}>
+                      {band.lastfm!.genres.slice(0, 5).map((genre) => (
+                        <span key={genre} className={styles.genreBadge}>
+                          {genre}
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                  {hasLastfmUrl && (
+                    <a
+                      className={styles.lastfmLink}
+                      href={band.lastfm!.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="View on Last.fm"
+                      title="View on Last.fm"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="9"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        />
+                        <text
+                          x="12"
+                          y="12"
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                          fontSize="7.5"
+                          fontWeight="700"
+                          fontFamily="sans-serif"
+                          fill="currentColor"
+                        >
+                          lfm
+                        </text>
+                      </svg>
+                    </a>
+                  )}
                 </div>
               )}
             </div>
@@ -93,11 +142,11 @@ export default async function BandPage({ params }: { params: Promise<{ slug: str
 
           <ul className="list-unstyled">
             {concerts.map((concert) => {
-              return <ConcertCard key={concert.id} concert={concert} />;
+              return <ConcertCard key={concert.id} concert={concert} />
             })}
           </ul>
         </div>
       </main>
     </Layout>
-  );
+  )
 }


### PR DESCRIPTION
- Added rules for creating feature and fix branches in the contribution guidelines.
- Improved SCSS styling for the band page, including adjustments to the ConcertCount display and new metaRow for Last.fm links and genres.
- Enhanced accessibility and hover effects for Last.fm links.

These changes streamline the development process and improve the user interface on the band page.