### PR TITLE
chore: implement PostHog consent management and session replay config…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,8 @@ DEV_USER_EMAIL=""
 NEXT_PUBLIC_POSTHOG_KEY=""
 NEXT_PUBLIC_POSTHOG_HOST="https://eu.i.posthog.com"
 NEXT_PUBLIC_POSTHOG_ENABLED="false"
+# Session replay remains off unless explicitly enabled and user consent is granted.
+NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED="false"
 
 # Sentry (from https://sentry.io → Project Settings → Client Keys DSN)
 NEXT_PUBLIC_SENTRY_DSN="https://...@....ingest.sentry.io/..."

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -4,6 +4,11 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { useTypedSession } from "@/lib/auth-client"
+import {
+  getPostHogConsentState,
+  setPostHogConsentState,
+} from "@/lib/posthog-consent"
+import { applyPostHogConsentState } from "@/lib/posthog-client"
 import "./settings.scss"
 
 export default function SettingsPage() {
@@ -21,6 +26,7 @@ export default function SettingsPage() {
     useState(session?.user?.includeUserIdInErrorReports ?? true)
   const [currency, setCurrency] = useState(session?.user?.currency || "EUR")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [analyticsConsent, setAnalyticsConsent] = useState(false)
   const [message, setMessage] = useState<{
     type: "success" | "error"
     text: string
@@ -39,6 +45,10 @@ export default function SettingsPage() {
       )
     }
   }, [session?.user])
+
+  useEffect(() => {
+    setAnalyticsConsent(getPostHogConsentState() === "granted")
+  }, [])
 
   if (isPending) {
     return (
@@ -274,6 +284,26 @@ export default function SettingsPage() {
                 <span className="settings__hint">
                   When enabled, we associate error reports with your account so
                   we can fix problems; you can turn this off at any time.
+                </span>
+              </div>
+
+              <div className="settings__field settings__checkbox">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={analyticsConsent}
+                    onChange={(e) => {
+                      const consented = e.target.checked
+                      setAnalyticsConsent(consented)
+                      setPostHogConsentState(consented ? "granted" : "denied")
+                      void applyPostHogConsentState(consented)
+                    }}
+                  />
+                  Allow analytics and session replay
+                </label>
+                <span className="settings__hint">
+                  Uses PostHog for page analytics and optional session replay.
+                  You can change this at any time.
                 </span>
               </div>
             </div>

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -292,11 +292,22 @@ export default function SettingsPage() {
                   <input
                     type="checkbox"
                     checked={analyticsConsent}
-                    onChange={(e) => {
+                    onChange={async (e) => {
                       const consented = e.target.checked
+                      const previousConsented = analyticsConsent
+
                       setAnalyticsConsent(consented)
                       setPostHogConsentState(consented ? "granted" : "denied")
-                      void applyPostHogConsentState(consented)
+
+                      try {
+                        await applyPostHogConsentState(consented)
+                      } catch (error) {
+                        console.error("Failed to apply PostHog consent state", error)
+                        setAnalyticsConsent(previousConsented)
+                        setPostHogConsentState(
+                          previousConsented ? "granted" : "denied",
+                        )
+                      }
                     }}
                   />
                   Allow analytics and session replay

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -9,6 +9,7 @@ import {
   setPostHogConsentState,
 } from "@/lib/posthog-consent"
 import { applyPostHogConsentState } from "@/lib/posthog-client"
+import { isPostHogSessionReplayEnabled } from "@/lib/posthog-env"
 import "./settings.scss"
 
 export default function SettingsPage() {
@@ -297,24 +298,39 @@ export default function SettingsPage() {
                       const previousConsented = analyticsConsent
 
                       setAnalyticsConsent(consented)
-                      setPostHogConsentState(consented ? "granted" : "denied")
+                      const persisted = setPostHogConsentState(
+                        consented ? "granted" : "denied"
+                      )
+
+                      if (!persisted) {
+                        setAnalyticsConsent(previousConsented)
+                        return
+                      }
 
                       try {
                         await applyPostHogConsentState(consented)
                       } catch (error) {
-                        console.error("Failed to apply PostHog consent state", error)
+                        console.error(
+                          "Failed to apply PostHog consent state",
+                          error
+                        )
                         setAnalyticsConsent(previousConsented)
                         setPostHogConsentState(
-                          previousConsented ? "granted" : "denied",
+                          previousConsented ? "granted" : "denied"
                         )
                       }
                     }}
                   />
-                  Allow analytics and session replay
+                  {isPostHogSessionReplayEnabled()
+                    ? "Allow analytics and session replay"
+                    : "Allow analytics"}
                 </label>
                 <span className="settings__hint">
-                  Uses PostHog for page analytics and optional session replay.
-                  You can change this at any time.
+                  Uses PostHog for page analytics
+                  {isPostHogSessionReplayEnabled()
+                    ? " and optional session replay"
+                    : ""}
+                  . You can change this at any time.
                 </span>
               </div>
             </div>

--- a/app/SessionAwareShell.tsx
+++ b/app/SessionAwareShell.tsx
@@ -1,6 +1,7 @@
 import { headers } from "next/headers"
 import * as Sentry from "@sentry/nextjs"
 import { auth } from "@/lib/auth"
+import PostHogConsentBanner from "@/components/PostHogConsentBanner/PostHogConsentBanner"
 import PostHogUserSync from "@/components/PostHogUserSync/PostHogUserSync"
 import SentryUserSetter from "@/components/SentryUserSetter/SentryUserSetter"
 
@@ -25,6 +26,7 @@ export default async function SessionAwareShell({
   return (
     <>
       <SentryUserSetter userId={sentryUserId} />
+      <PostHogConsentBanner />
       <PostHogUserSync userId={postHogUserId} />
       {children}
     </>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -339,8 +339,9 @@ export default function PrivacyPage() {
               signed in, we link events to your <strong>internal user</strong>{" "}
               identifier only — we do not send your email address or name to
               PostHog for this purpose. We configure PostHog without DOM
-              autocapture of clicks or form fields. If you explicitly consent,
-              we may also process session replay data (for example, page
+              autocapture of clicks or form fields. If you explicitly consent
+              and session replay is enabled in our deployment configuration, we
+              may also process session replay data (for example, page
               transitions, interaction timeline, and technical rendering state)
               to diagnose usability and reliability issues.
             </p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -340,7 +340,7 @@ export default function PrivacyPage() {
               identifier only — we do not send your email address or name to
               PostHog for this purpose. We configure PostHog without DOM
               autocapture of clicks or form fields. If you explicitly consent,
-              we may also process session replay data (for example page
+              we may also process session replay data (for example, page
               transitions, interaction timeline, and technical rendering state)
               to diagnose usability and reliability issues.
             </p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -338,9 +338,11 @@ export default function PrivacyPage() {
               information as processed by PostHog), and page URLs. If you are
               signed in, we link events to your <strong>internal user</strong>{" "}
               identifier only — we do not send your email address or name to
-              PostHog for this purpose. We have configured PostHog without
-              session replay and without DOM autocapture of clicks or form
-              fields, to limit the data collected.
+              PostHog for this purpose. We configure PostHog without DOM
+              autocapture of clicks or form fields. If you explicitly consent,
+              we may also process session replay data (for example page
+              transitions, interaction timeline, and technical rendering state)
+              to diagnose usability and reliability issues.
             </p>
             <p>
               PostHog acts as a <strong>processor</strong> on our instructions.
@@ -362,15 +364,16 @@ export default function PrivacyPage() {
                 posthog.com/dpa
               </a>
               . Analytics is only active when we enable it in our deployment
-              configuration; when disabled, no usage events are sent to PostHog.
+              configuration and when you have granted consent. You can withdraw
+              consent at any time in <a href="/settings">Settings</a>.
             </p>
             <p>
-              <strong>Legal basis:</strong> The appropriate legal basis (for
-              example consent under Art. 6(1)(a) GDPR / § 25 TTDSG, or
-              legitimate interest under Art. 6(1)(f) GDPR with a balancing test)
-              depends on how we roll out analytics in your jurisdiction. This
-              policy will be updated to match the basis we rely on after legal
-              review. We do not use PostHog for behavioural advertising.
+              <strong>Legal basis:</strong> Consent (Art. 6(1)(a) GDPR and,
+              where applicable, § 25 TTDSG for storage/access on your end
+              device). We do not activate PostHog analytics or session replay
+              before your consent. You may withdraw consent at any time for
+              future processing, without affecting processing performed before
+              withdrawal.
             </p>
             <p>
               The use of storage and similar technologies is carried out in

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -30,6 +30,8 @@ Sentry.init({
   sendDefaultPii: false,
 })
 
-void initPostHogIfConsented()
+void initPostHogIfConsented().catch((error) => {
+  console.error("PostHog initialization failed", error)
+})
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,7 @@
 
 import * as Sentry from "@sentry/nextjs"
 
-import { getPostHogApiHost, isPostHogAnalyticsEnabled } from "@/lib/posthog-env"
+import { initPostHogIfConsented } from "@/lib/posthog-client"
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -30,18 +30,6 @@ Sentry.init({
   sendDefaultPii: false,
 })
 
-if (isPostHogAnalyticsEnabled()) {
-  import("posthog-js").then(({ default: posthog }) => {
-    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY!.trim()
-    posthog.init(key, {
-      api_host: getPostHogApiHost(),
-      autocapture: false,
-      capture_exceptions: false,
-      capture_pageview: "history_change",
-      disable_session_recording: true,
-      persistence: "localStorage",
-    })
-  })
-}
+void initPostHogIfConsented()
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
+import "./.next/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/PostHogConsentBanner/PostHogConsentBanner.scss
+++ b/src/components/PostHogConsentBanner/PostHogConsentBanner.scss
@@ -1,0 +1,59 @@
+@use "../../styles/variables.scss";
+
+.posthog-consent-banner {
+  background: variables.$color-white;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  bottom: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-width: 560px;
+  padding: 1rem;
+  position: fixed;
+  right: 1rem;
+  width: calc(100% - 2rem);
+  z-index: 1000;
+
+  &__text {
+    margin: 0 0 0.75rem;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-bottom: 0.5rem;
+  }
+
+  &__button {
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: variables.$font-family-text;
+    font-size: 0.875rem;
+    padding: 0.5rem 0.75rem;
+    transition:
+      background-color variables.$transition-duration
+        variables.$transition-easing-decelerate,
+      color variables.$transition-duration
+        variables.$transition-easing-decelerate,
+      border-color variables.$transition-duration
+        variables.$transition-easing-decelerate;
+
+    &--primary {
+      background: variables.$color-primary;
+      border: 1px solid variables.$color-primary;
+      color: variables.$color-white;
+    }
+
+    &--secondary {
+      background: variables.$color-white;
+      border: 1px solid #ccc;
+      color: #333;
+    }
+  }
+
+  &__meta {
+    color: #555;
+    font-size: 0.75rem;
+    margin: 0;
+  }
+}

--- a/src/components/PostHogConsentBanner/PostHogConsentBanner.scss
+++ b/src/components/PostHogConsentBanner/PostHogConsentBanner.scss
@@ -17,6 +17,16 @@
     margin: 0 0 0.75rem;
   }
 
+  &__error {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 6px;
+    color: #b91c1c;
+    font-size: 0.875rem;
+    margin: 0 0 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
   &__actions {
     display: flex;
     gap: 0.5rem;

--- a/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
+++ b/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { useState, useSyncExternalStore } from "react"
 
 import {
   getPostHogConsentState,
@@ -9,53 +9,75 @@ import {
   setPostHogConsentState,
 } from "@/lib/posthog-consent"
 import { applyPostHogConsentState } from "@/lib/posthog-client"
-import { isPostHogAnalyticsEnabled } from "@/lib/posthog-env"
+import {
+  isPostHogAnalyticsEnabled,
+  isPostHogSessionReplayEnabled,
+} from "@/lib/posthog-env"
 
 import "./PostHogConsentBanner.scss"
 
-export default function PostHogConsentBanner() {
-  const [isReady, setIsReady] = useState(false)
-  const [showBanner, setShowBanner] = useState(false)
+function subscribeToConsentChanges(callback: () => void) {
+  window.addEventListener(POSTHOG_CONSENT_EVENT, callback)
+  return () => window.removeEventListener(POSTHOG_CONSENT_EVENT, callback)
+}
 
-  useEffect(() => {
-    if (!isPostHogAnalyticsEnabled()) {
-      setIsReady(true)
+function getConsentSnapshot() {
+  return getPostHogConsentState()
+}
+
+function getServerSnapshot() {
+  return null
+}
+
+export default function PostHogConsentBanner() {
+  const consentState = useSyncExternalStore(
+    subscribeToConsentChanges,
+    getConsentSnapshot,
+    getServerSnapshot
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  const analyticsEnabled = isPostHogAnalyticsEnabled()
+  const showBanner = analyticsEnabled && consentState === null
+
+  const handleConsentChange = async (consented: boolean) => {
+    setError(null)
+
+    const persisted = setPostHogConsentState(consented ? "granted" : "denied")
+    if (!persisted) {
+      setError(
+        "Could not save your preference. Please check your browser settings."
+      )
       return
     }
 
-    setShowBanner(getPostHogConsentState() === null)
-    setIsReady(true)
-
-    const handleConsentEvent = () => {
-      setShowBanner(getPostHogConsentState() === null)
-    }
-
-    window.addEventListener(POSTHOG_CONSENT_EVENT, handleConsentEvent)
-    return () => {
-      window.removeEventListener(POSTHOG_CONSENT_EVENT, handleConsentEvent)
-    }
-  }, [])
-
-  const handleConsentChange = async (consented: boolean) => {
-    setPostHogConsentState(consented ? "granted" : "denied")
-
     try {
       await applyPostHogConsentState(consented)
-    } catch (error) {
-      console.error("Failed to apply PostHog consent state", error)
-    } finally {
-      setShowBanner(false)
+    } catch (err) {
+      console.error("Failed to apply PostHog consent state", err)
+      setError("Something went wrong. Please try again.")
     }
   }
 
-  if (!isReady || !showBanner) return null
+  if (!showBanner) return null
+
+  const replayEnabled = isPostHogSessionReplayEnabled()
+  const acceptLabel = replayEnabled
+    ? "Accept analytics and replay"
+    : "Accept analytics"
 
   return (
     <aside className="posthog-consent-banner" aria-label="Analytics consent">
       <p className="posthog-consent-banner__text">
-        We use analytics and optional session replay to improve reliability and
-        usability. This is only active with your consent.
+        We use analytics{replayEnabled ? " and optional session replay" : ""} to
+        improve reliability and usability. This is only active with your
+        consent.
       </p>
+      {error && (
+        <p className="posthog-consent-banner__error" role="alert">
+          {error}
+        </p>
+      )}
       <div className="posthog-consent-banner__actions">
         <button
           className="posthog-consent-banner__button posthog-consent-banner__button--secondary"
@@ -69,7 +91,7 @@ export default function PostHogConsentBanner() {
           type="button"
           onClick={() => void handleConsentChange(true)}
         >
-          Accept analytics
+          {acceptLabel}
         </button>
       </div>
       <p className="posthog-consent-banner__meta">

--- a/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
+++ b/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
@@ -69,7 +69,7 @@ export default function PostHogConsentBanner() {
           type="button"
           onClick={() => void handleConsentChange(true)}
         >
-          Accept analytics and replay
+          Accept analytics
         </button>
       </div>
       <p className="posthog-consent-banner__meta">

--- a/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
+++ b/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useState } from "react"
+
+import {
+  getPostHogConsentState,
+  POSTHOG_CONSENT_EVENT,
+  setPostHogConsentState,
+} from "@/lib/posthog-consent"
+import { applyPostHogConsentState } from "@/lib/posthog-client"
+import { isPostHogAnalyticsEnabled } from "@/lib/posthog-env"
+
+import "./PostHogConsentBanner.scss"
+
+export default function PostHogConsentBanner() {
+  const [isReady, setIsReady] = useState(false)
+  const [showBanner, setShowBanner] = useState(false)
+
+  useEffect(() => {
+    if (!isPostHogAnalyticsEnabled()) {
+      setIsReady(true)
+      return
+    }
+
+    setShowBanner(getPostHogConsentState() === null)
+    setIsReady(true)
+
+    const handleConsentEvent = () => {
+      setShowBanner(getPostHogConsentState() === null)
+    }
+
+    window.addEventListener(POSTHOG_CONSENT_EVENT, handleConsentEvent)
+    return () => {
+      window.removeEventListener(POSTHOG_CONSENT_EVENT, handleConsentEvent)
+    }
+  }, [])
+
+  const handleConsentChange = async (consented: boolean) => {
+    setPostHogConsentState(consented ? "granted" : "denied")
+    await applyPostHogConsentState(consented)
+    setShowBanner(false)
+  }
+
+  if (!isReady || !showBanner) return null
+
+  return (
+    <aside className="posthog-consent-banner" aria-label="Analytics consent">
+      <p className="posthog-consent-banner__text">
+        We use analytics and optional session replay to improve reliability and
+        usability. This is only active with your consent.
+      </p>
+      <div className="posthog-consent-banner__actions">
+        <button
+          className="posthog-consent-banner__button posthog-consent-banner__button--secondary"
+          type="button"
+          onClick={() => void handleConsentChange(false)}
+        >
+          Decline
+        </button>
+        <button
+          className="posthog-consent-banner__button posthog-consent-banner__button--primary"
+          type="button"
+          onClick={() => void handleConsentChange(true)}
+        >
+          Accept analytics and replay
+        </button>
+      </div>
+      <p className="posthog-consent-banner__meta">
+        You can change this anytime in <Link href="/settings">Settings</Link> or
+        in our <Link href="/privacy">Privacy Policy</Link>.
+      </p>
+    </aside>
+  )
+}

--- a/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
+++ b/src/components/PostHogConsentBanner/PostHogConsentBanner.tsx
@@ -38,8 +38,14 @@ export default function PostHogConsentBanner() {
 
   const handleConsentChange = async (consented: boolean) => {
     setPostHogConsentState(consented ? "granted" : "denied")
-    await applyPostHogConsentState(consented)
-    setShowBanner(false)
+
+    try {
+      await applyPostHogConsentState(consented)
+    } catch (error) {
+      console.error("Failed to apply PostHog consent state", error)
+    } finally {
+      setShowBanner(false)
+    }
   }
 
   if (!isReady || !showBanner) return null

--- a/src/components/PostHogUserSync/PostHogUserSync.tsx
+++ b/src/components/PostHogUserSync/PostHogUserSync.tsx
@@ -16,18 +16,27 @@ export default function PostHogUserSync({ userId }: PostHogUserSyncProps) {
   const previousUserId = useRef<string | null | undefined>(undefined)
 
   useEffect(() => {
-    initPostHogIfConsented().then((isInitialized) => {
-      if (!isInitialized) return
-      import("posthog-js").then(({ default: posthog }) => {
-        if (userId) {
-          posthog.identify(userId)
-        } else if (previousUserId.current) {
-          posthog.reset()
-        }
+    let active = true
 
-        previousUserId.current = userId
-      })
-    })
+    void (async () => {
+      const isInitialized = await initPostHogIfConsented()
+      if (!active || !isInitialized) return
+
+      const { default: posthog } = await import("posthog-js")
+      if (!active) return
+
+      if (userId) {
+        posthog.identify(userId)
+      } else if (previousUserId.current) {
+        posthog.reset()
+      }
+
+      previousUserId.current = userId
+    })()
+
+    return () => {
+      active = false
+    }
   }, [userId])
 
   return null

--- a/src/components/PostHogUserSync/PostHogUserSync.tsx
+++ b/src/components/PostHogUserSync/PostHogUserSync.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { initPostHogIfConsented } from "@/lib/posthog-client"
+import { POSTHOG_CONSENT_EVENT, hasPostHogConsent } from "@/lib/posthog-consent"
 
 interface PostHogUserSyncProps {
   userId: string | null
@@ -11,9 +12,22 @@ interface PostHogUserSyncProps {
 /**
  * Links PostHog to the signed-in user using the internal user id only (no email/PII).
  * Calls reset only when transitioning from a known user to logged out (not on every anonymous page load).
+ * Re-runs identify when consent is granted so the current user is linked immediately after opt-in.
  */
 export default function PostHogUserSync({ userId }: PostHogUserSyncProps) {
   const previousUserId = useRef<string | null | undefined>(undefined)
+  const [consentGranted, setConsentGranted] = useState(() => hasPostHogConsent())
+
+  useEffect(() => {
+    const handleConsentChange = () => {
+      setConsentGranted(hasPostHogConsent())
+    }
+
+    window.addEventListener(POSTHOG_CONSENT_EVENT, handleConsentChange)
+    return () => {
+      window.removeEventListener(POSTHOG_CONSENT_EVENT, handleConsentChange)
+    }
+  }, [])
 
   useEffect(() => {
     let active = true
@@ -37,7 +51,7 @@ export default function PostHogUserSync({ userId }: PostHogUserSyncProps) {
     return () => {
       active = false
     }
-  }, [userId])
+  }, [userId, consentGranted])
 
   return null
 }

--- a/src/components/PostHogUserSync/PostHogUserSync.tsx
+++ b/src/components/PostHogUserSync/PostHogUserSync.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react"
 
-import { isPostHogAnalyticsEnabled } from "@/lib/posthog-env"
+import { initPostHogIfConsented } from "@/lib/posthog-client"
 
 interface PostHogUserSyncProps {
   userId: string | null
@@ -16,16 +16,17 @@ export default function PostHogUserSync({ userId }: PostHogUserSyncProps) {
   const previousUserId = useRef<string | null | undefined>(undefined)
 
   useEffect(() => {
-    if (!isPostHogAnalyticsEnabled()) return
+    initPostHogIfConsented().then((isInitialized) => {
+      if (!isInitialized) return
+      import("posthog-js").then(({ default: posthog }) => {
+        if (userId) {
+          posthog.identify(userId)
+        } else if (previousUserId.current) {
+          posthog.reset()
+        }
 
-    import("posthog-js").then(({ default: posthog }) => {
-      if (userId) {
-        posthog.identify(userId)
-      } else if (previousUserId.current) {
-        posthog.reset()
-      }
-
-      previousUserId.current = userId
+        previousUserId.current = userId
+      })
     })
   }, [userId])
 

--- a/src/lib/__tests__/posthog-consent.test.ts
+++ b/src/lib/__tests__/posthog-consent.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import {
+  POSTHOG_CONSENT_STORAGE_KEY,
+  POSTHOG_CONSENT_EVENT,
+  getPostHogConsentState,
+  hasPostHogConsent,
+  setPostHogConsentState,
+} from "../posthog-consent"
+
+describe("posthog-consent", () => {
+  const originalWindow = global.window
+
+  beforeEach(() => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+      },
+      dispatchEvent: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (originalWindow === undefined) {
+      // @ts-expect-error - resetting window for SSR tests
+      delete global.window
+    }
+  })
+
+  describe("constants", () => {
+    it("exports correct storage key", () => {
+      expect(POSTHOG_CONSENT_STORAGE_KEY).toBe("concerts_posthog_consent_v1")
+    })
+
+    it("exports correct event name", () => {
+      expect(POSTHOG_CONSENT_EVENT).toBe("concerts:posthog-consent-changed")
+    })
+  })
+
+  describe("getPostHogConsentState", () => {
+    it("returns null when window is undefined (SSR)", () => {
+      vi.stubGlobal("window", undefined)
+      expect(getPostHogConsentState()).toBeNull()
+    })
+
+    it("returns 'granted' when localStorage has 'granted'", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue("granted")
+      expect(getPostHogConsentState()).toBe("granted")
+      expect(window.localStorage.getItem).toHaveBeenCalledWith(
+        POSTHOG_CONSENT_STORAGE_KEY
+      )
+    })
+
+    it("returns 'denied' when localStorage has 'denied'", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue("denied")
+      expect(getPostHogConsentState()).toBe("denied")
+    })
+
+    it("returns null when localStorage has null", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue(null)
+      expect(getPostHogConsentState()).toBeNull()
+    })
+
+    it("returns null when localStorage has invalid value", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue("invalid")
+      expect(getPostHogConsentState()).toBeNull()
+    })
+
+    it("returns null when localStorage has empty string", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue("")
+      expect(getPostHogConsentState()).toBeNull()
+    })
+
+    it("returns null when localStorage throws (e.g., Safari private mode)", () => {
+      vi.mocked(window.localStorage.getItem).mockImplementation(() => {
+        throw new Error("localStorage is disabled")
+      })
+      expect(getPostHogConsentState()).toBeNull()
+    })
+  })
+
+  describe("hasPostHogConsent", () => {
+    it("returns true when consent state is 'granted'", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue("granted")
+      expect(hasPostHogConsent()).toBe(true)
+    })
+
+    it("returns false when consent state is 'denied'", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue("denied")
+      expect(hasPostHogConsent()).toBe(false)
+    })
+
+    it("returns false when consent state is null", () => {
+      vi.mocked(window.localStorage.getItem).mockReturnValue(null)
+      expect(hasPostHogConsent()).toBe(false)
+    })
+
+    it("returns false when localStorage throws", () => {
+      vi.mocked(window.localStorage.getItem).mockImplementation(() => {
+        throw new Error("localStorage is disabled")
+      })
+      expect(hasPostHogConsent()).toBe(false)
+    })
+  })
+
+  describe("setPostHogConsentState", () => {
+    it("returns false when window is undefined (SSR)", () => {
+      vi.stubGlobal("window", undefined)
+      expect(setPostHogConsentState("granted")).toBe(false)
+    })
+
+    it("stores 'granted' in localStorage and returns true", () => {
+      const result = setPostHogConsentState("granted")
+
+      expect(result).toBe(true)
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        POSTHOG_CONSENT_STORAGE_KEY,
+        "granted"
+      )
+    })
+
+    it("stores 'denied' in localStorage and returns true", () => {
+      const result = setPostHogConsentState("denied")
+
+      expect(result).toBe(true)
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        POSTHOG_CONSENT_STORAGE_KEY,
+        "denied"
+      )
+    })
+
+    it("dispatches consent changed event", () => {
+      setPostHogConsentState("granted")
+
+      expect(window.dispatchEvent).toHaveBeenCalledTimes(1)
+      const dispatchedEvent = vi.mocked(window.dispatchEvent).mock.calls[0][0]
+      expect(dispatchedEvent).toBeInstanceOf(Event)
+      expect(dispatchedEvent.type).toBe(POSTHOG_CONSENT_EVENT)
+    })
+
+    it("returns false when localStorage.setItem throws (quota exceeded)", () => {
+      vi.mocked(window.localStorage.setItem).mockImplementation(() => {
+        throw new Error("QuotaExceededError")
+      })
+
+      const result = setPostHogConsentState("granted")
+
+      expect(result).toBe(false)
+      expect(window.dispatchEvent).not.toHaveBeenCalled()
+    })
+
+    it("returns false when localStorage.setItem throws (Safari private mode)", () => {
+      vi.mocked(window.localStorage.setItem).mockImplementation(() => {
+        throw new DOMException(
+          "The quota has been exceeded.",
+          "QuotaExceededError"
+        )
+      })
+
+      const result = setPostHogConsentState("denied")
+
+      expect(result).toBe(false)
+      expect(window.dispatchEvent).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/__tests__/posthog-env.test.ts
+++ b/src/lib/__tests__/posthog-env.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { isPostHogAnalyticsEnabled, getPostHogApiHost } from "../posthog-env"
+import {
+  isPostHogAnalyticsEnabled,
+  getPostHogApiHost,
+  isPostHogSessionReplayEnabled,
+} from "../posthog-env"
 
 describe("posthog-env", () => {
   beforeEach(() => {
@@ -142,6 +146,31 @@ describe("posthog-env", () => {
     it("returns self-hosted URL when configured", () => {
       vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://analytics.example.com")
       expect(getPostHogApiHost()).toBe("https://analytics.example.com")
+    })
+  })
+
+  describe("isPostHogSessionReplayEnabled", () => {
+    it("returns false when NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED is undefined", () => {
+      expect(isPostHogSessionReplayEnabled()).toBe(false)
+    })
+
+    it("returns false for disabled values", () => {
+      vi.stubEnv("NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED", "false")
+      expect(isPostHogSessionReplayEnabled()).toBe(false)
+
+      vi.stubEnv("NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED", "0")
+      expect(isPostHogSessionReplayEnabled()).toBe(false)
+    })
+
+    it("returns true for explicit enabled values", () => {
+      vi.stubEnv("NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED", "true")
+      expect(isPostHogSessionReplayEnabled()).toBe(true)
+
+      vi.stubEnv("NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED", "1")
+      expect(isPostHogSessionReplayEnabled()).toBe(true)
+
+      vi.stubEnv("NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED", "yes")
+      expect(isPostHogSessionReplayEnabled()).toBe(true)
     })
   })
 })

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -1,0 +1,51 @@
+import {
+  getPostHogApiHost,
+  isPostHogAnalyticsEnabled,
+  isPostHogSessionReplayEnabled,
+} from "@/lib/posthog-env"
+import { hasPostHogConsent } from "@/lib/posthog-consent"
+
+let initPromise: Promise<void> | null = null
+
+function canUsePostHog() {
+  return (
+    typeof window !== "undefined" &&
+    isPostHogAnalyticsEnabled() &&
+    hasPostHogConsent()
+  )
+}
+
+export async function initPostHogIfConsented(): Promise<boolean> {
+  if (!canUsePostHog()) return false
+
+  if (!initPromise) {
+    initPromise = import("posthog-js").then(({ default: posthog }) => {
+      const key = process.env.NEXT_PUBLIC_POSTHOG_KEY!.trim()
+      posthog.init(key, {
+        api_host: getPostHogApiHost(),
+        autocapture: false,
+        capture_exceptions: false,
+        capture_pageview: "history_change",
+        disable_session_recording: !isPostHogSessionReplayEnabled(),
+        persistence: "localStorage",
+      })
+    })
+  }
+
+  await initPromise
+  return true
+}
+
+export async function applyPostHogConsentState(consented: boolean) {
+  if (!isPostHogAnalyticsEnabled() || typeof window === "undefined") return
+
+  const { default: posthog } = await import("posthog-js")
+  if (consented) {
+    await initPostHogIfConsented()
+    posthog.opt_in_capturing()
+    return
+  }
+
+  posthog.opt_out_capturing()
+  posthog.reset()
+}

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -19,17 +19,22 @@ export async function initPostHogIfConsented(): Promise<boolean> {
   if (!canUsePostHog()) return false
 
   if (!initPromise) {
-    initPromise = import("posthog-js").then(({ default: posthog }) => {
-      const key = process.env.NEXT_PUBLIC_POSTHOG_KEY!.trim()
-      posthog.init(key, {
-        api_host: getPostHogApiHost(),
-        autocapture: false,
-        capture_exceptions: false,
-        capture_pageview: "history_change",
-        disable_session_recording: !isPostHogSessionReplayEnabled(),
-        persistence: "localStorage",
+    initPromise = import("posthog-js")
+      .then(({ default: posthog }) => {
+        const key = process.env.NEXT_PUBLIC_POSTHOG_KEY!.trim()
+        posthog.init(key, {
+          api_host: getPostHogApiHost(),
+          autocapture: false,
+          capture_exceptions: false,
+          capture_pageview: "history_change",
+          disable_session_recording: !isPostHogSessionReplayEnabled(),
+          persistence: "localStorage",
+        })
       })
-    })
+      .catch((error) => {
+        initPromise = null
+        throw error
+      })
   }
 
   await initPromise

--- a/src/lib/posthog-client.ts
+++ b/src/lib/posthog-client.ts
@@ -44,13 +44,17 @@ export async function initPostHogIfConsented(): Promise<boolean> {
 export async function applyPostHogConsentState(consented: boolean) {
   if (!isPostHogAnalyticsEnabled() || typeof window === "undefined") return
 
-  const { default: posthog } = await import("posthog-js")
   if (consented) {
     await initPostHogIfConsented()
+    const { default: posthog } = await import("posthog-js")
     posthog.opt_in_capturing()
     return
   }
 
+  if (!initPromise) return
+
+  await initPromise
+  const { default: posthog } = await import("posthog-js")
   posthog.opt_out_capturing()
   posthog.reset()
 }

--- a/src/lib/posthog-consent.ts
+++ b/src/lib/posthog-consent.ts
@@ -21,9 +21,14 @@ export function hasPostHogConsent(): boolean {
 
 export function setPostHogConsentState(
   state: Exclude<PostHogConsentState, null>
-) {
-  if (typeof window === "undefined") return
+): boolean {
+  if (typeof window === "undefined") return false
 
-  window.localStorage.setItem(POSTHOG_CONSENT_STORAGE_KEY, state)
-  window.dispatchEvent(new Event(POSTHOG_CONSENT_EVENT))
+  try {
+    window.localStorage.setItem(POSTHOG_CONSENT_STORAGE_KEY, state)
+    window.dispatchEvent(new Event(POSTHOG_CONSENT_EVENT))
+    return true
+  } catch {
+    return false
+  }
 }

--- a/src/lib/posthog-consent.ts
+++ b/src/lib/posthog-consent.ts
@@ -6,9 +6,13 @@ export type PostHogConsentState = "granted" | "denied" | null
 export function getPostHogConsentState(): PostHogConsentState {
   if (typeof window === "undefined") return null
 
-  const value = window.localStorage.getItem(POSTHOG_CONSENT_STORAGE_KEY)
-  if (value === "granted" || value === "denied") return value
-  return null
+  try {
+    const value = window.localStorage.getItem(POSTHOG_CONSENT_STORAGE_KEY)
+    if (value === "granted" || value === "denied") return value
+    return null
+  } catch {
+    return null
+  }
 }
 
 export function hasPostHogConsent(): boolean {

--- a/src/lib/posthog-consent.ts
+++ b/src/lib/posthog-consent.ts
@@ -1,0 +1,25 @@
+export const POSTHOG_CONSENT_STORAGE_KEY = "concerts_posthog_consent_v1"
+export const POSTHOG_CONSENT_EVENT = "concerts:posthog-consent-changed"
+
+export type PostHogConsentState = "granted" | "denied" | null
+
+export function getPostHogConsentState(): PostHogConsentState {
+  if (typeof window === "undefined") return null
+
+  const value = window.localStorage.getItem(POSTHOG_CONSENT_STORAGE_KEY)
+  if (value === "granted" || value === "denied") return value
+  return null
+}
+
+export function hasPostHogConsent(): boolean {
+  return getPostHogConsentState() === "granted"
+}
+
+export function setPostHogConsentState(
+  state: Exclude<PostHogConsentState, null>
+) {
+  if (typeof window === "undefined") return
+
+  window.localStorage.setItem(POSTHOG_CONSENT_STORAGE_KEY, state)
+  window.dispatchEvent(new Event(POSTHOG_CONSENT_EVENT))
+}

--- a/src/lib/posthog-env.ts
+++ b/src/lib/posthog-env.ts
@@ -14,3 +14,13 @@ export function getPostHogApiHost(): string {
     process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim() || "https://eu.i.posthog.com"
   )
 }
+
+/**
+ * Session replay is opt-in behind an explicit env flag.
+ * Keep disabled by default until legal and UX controls are in place.
+ */
+export function isPostHogSessionReplayEnabled(): boolean {
+  const flag =
+    process.env.NEXT_PUBLIC_POSTHOG_SESSION_REPLAY_ENABLED?.toLowerCase()
+  return flag === "true" || flag === "1" || flag === "yes"
+}


### PR DESCRIPTION
…uration

- Added PostHog consent banner component to manage user consent for analytics and session replay.
- Updated settings page to allow users to grant or deny analytics consent, with state management for user preferences.
- Enhanced privacy policy to clarify data handling and consent requirements for analytics and session replay.
- Introduced new utility functions for managing PostHog consent state and session replay settings.
- Updated environment configuration to include session replay feature flag in .env.example.
- Refactored instrumentation-client and user sync components to initialize PostHog based on user consent.